### PR TITLE
Fixes for Lua 5.0 and 5.1

### DIFF
--- a/src/binding-factory.ts
+++ b/src/binding-factory.ts
@@ -157,9 +157,11 @@ export function createLua(luaGlue: LuaEmscriptenModule, version: string): Lua {
 
 type lauxBindingFactoryFunc = (luaGlue: LuaEmscriptenModule, lua: Lua) => Partial<LauxLib>;
 const lauxBindings: Record<string, lauxBindingFactoryFunc> = {
-    "5.0.x": function(luaGlue: LuaEmscriptenModule, _lua: Lua) {
+    "5.0.x": function(luaGlue: LuaEmscriptenModule, lua: Lua) {
         return {
-            luaL_dostring: luaGlue.cwrap("luaL_dostring", "number", ["number", "string"]),
+            luaL_dostring: function(L: LuaState, s: string) {
+                return (this as LauxLib).luaL_loadstring(L, s) || lua.lua_pcall(L, 0, LUA_MULTRET, 0);
+            },
             luaL_loadstring: function(L: LuaState, s: string) {
                 return (this as LauxLib).luaL_loadbuffer(L, s, s.length, s);
             },

--- a/src/binding-factory.ts
+++ b/src/binding-factory.ts
@@ -55,7 +55,7 @@ const luaBindings: Record<string, luaBindingFactoryFunc> = {
             lua_tostring: luaGlue.cwrap("lua_tostring", "number", ["number", "number"])
         };
     },
-    "5.1.x": function(_: LuaEmscriptenModule){
+    "5.1.x": function(_luaGlue: LuaEmscriptenModule){
         return {
             // #define lua_getglobal(L,s)  lua_getfield(L, LUA_GLOBALSINDEX, s)
             lua_getglobal: function (L: LuaState, name: string) {

--- a/src/binding-factory.ts
+++ b/src/binding-factory.ts
@@ -52,7 +52,7 @@ const luaBindings: Record<string, luaBindingFactoryFunc> = {
             lua_tolstring: function(_L: LuaState, _index: number, _size: number) {
                 throw "lua_tolstring is currently not supported in 5.0";
             },
-            lua_tostring: luaGlue.cwrap("lua_tostring", "number", ["number", "number"])
+            lua_tostring: luaGlue.cwrap("lua_tostring", "string", ["number", "number"])
         };
     },
     "5.1.x": function(_luaGlue: LuaEmscriptenModule){

--- a/src/binding-factory.ts
+++ b/src/binding-factory.ts
@@ -30,10 +30,10 @@ const luaBindings: Record<string, luaBindingFactoryFunc> = {
             lua_getfield: function(L: LuaState, index: number, k: string) {
                 (this as Lua).lua_pushstring(L, k);
 
-                // If the index is a relative offset, it needs to be corrected for the grown stack
-                const isOffset = index < 0 && index !== LUA_GLOBALSINDEX_50;
+                // Relative offsets must move if the stack pointer moves
+                const isRelativeOffset = index < 0 && index !== LUA_GLOBALSINDEX_50;
 
-                return (this as Lua).lua_gettable(L, isOffset ? index - 1 : index);
+                return (this as Lua).lua_gettable(L, isRelativeOffset ? index - 1 : index);
             },
             lua_setfield: function(L: LuaState, index: number, k: string) {
                 // The value to set is expected to be on the top of the stack
@@ -44,10 +44,10 @@ const luaBindings: Record<string, luaBindingFactoryFunc> = {
                 // Swap key and value because settable expects stack in that order
                 (this as Lua).lua_insert(L, -2);
     
-                // If the index is a relative offset, it needs to be corrected for the grown stack
-                const isOffset = index < 0 && index !== LUA_GLOBALSINDEX_50;
+                // Relative offsets must move if the stack pointer moves
+                const isRelativeOffset = index < 0 && index !== LUA_GLOBALSINDEX_50;
 
-                const result = (this as Lua).lua_settable(L, isOffset ? index - 1 : index);
+                const result = (this as Lua).lua_settable(L, isRelativeOffset ? index - 1 : index);
     
                 return result;
             },

--- a/src/lua.ts
+++ b/src/lua.ts
@@ -7,7 +7,8 @@ export type LuaState = number & LuaStateUnique;
 export const LUA_MULTRET = -1;
 
 // 5.0 & 5.1
-export const LUA_GLOBALSINDEX = -1002;
+export const LUA_GLOBALSINDEX_50 = -10001;
+export const LUA_GLOBALSINDEX_51 = -10002;
 
 // 5.2^
 export const LUA_RIDX_GLOBALS = 2;


### PR DESCRIPTION
Account for different globals index addresses, restore missing functions in 5.0, and fix some small errors. I've gotten all the 5.1 tests and some of the 5.0 tests to pass with these changes.