### PR TITLE
Fix Unicode strings for luaL_loadbuffer in Lua 5.0

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -20,7 +20,7 @@ cd ../..
 if [[ "$1" == "lua-5.0.3" ]]; then
     emcc -Ithirdparty/$1 thirdparty/$1/lib/liblua.a thirdparty/$1/lib/liblualib.a \
         -s WASM=1 -O3 -o dist/glue/glue-$1.js \
-        -s EXPORTED_RUNTIME_METHODS="['cwrap', 'stackSave', 'stackRestore', 'lengthBytesUTF8', 'allocateUTF8OnStack']" \
+        -s EXPORTED_RUNTIME_METHODS="['cwrap', 'lengthBytesUTF8']" \
         -s MODULARIZE=1 \
         -s ALLOW_TABLE_GROWTH \
         -s EXPORT_NAME="glue" \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -20,7 +20,7 @@ cd ../..
 if [[ "$1" == "lua-5.0.3" ]]; then
     emcc -Ithirdparty/$1 thirdparty/$1/lib/liblua.a thirdparty/$1/lib/liblualib.a \
         -s WASM=1 -O3 -o dist/glue/glue-$1.js \
-        -s EXPORTED_RUNTIME_METHODS="['cwrap', 'allocateUTF8', 'lengthBytesUTF8']" \
+        -s EXPORTED_RUNTIME_METHODS="['cwrap', 'stackSave', 'stackRestore', 'lengthBytesUTF8', 'allocateUTF8OnStack']" \
         -s MODULARIZE=1 \
         -s ALLOW_TABLE_GROWTH \
         -s EXPORT_NAME="glue" \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -20,7 +20,7 @@ cd ../..
 if [[ "$1" == "lua-5.0.3" ]]; then
     emcc -Ithirdparty/$1 thirdparty/$1/lib/liblua.a thirdparty/$1/lib/liblualib.a \
         -s WASM=1 -O3 -o dist/glue/glue-$1.js \
-        -s EXPORTED_RUNTIME_METHODS="['cwrap']" \
+        -s EXPORTED_RUNTIME_METHODS="['cwrap', 'allocateUTF8', 'lengthBytesUTF8']" \
         -s MODULARIZE=1 \
         -s ALLOW_TABLE_GROWTH \
         -s EXPORT_NAME="glue" \

--- a/src/binding-factory.ts
+++ b/src/binding-factory.ts
@@ -165,8 +165,11 @@ const lauxBindings: Record<string, lauxBindingFactoryFunc> = {
                 return (this as LauxLib).luaL_loadstring(L, s) || lua.lua_pcall(L, 0, LUA_MULTRET, 0);
             },
             luaL_loadstring: function(L: LuaState, s: string) {
-                const ptr = luaGlue.allocateUTF8(s) as unknown;
-                return (this as LauxLib).luaL_loadbuffer(L, ptr as string, luaGlue.lengthBytesUTF8(s), s);
+                const lastStack = luaGlue.stackSave();
+                const cstr = luaGlue.allocateUTF8OnStack(s) as unknown;
+                const result = (this as LauxLib).luaL_loadbuffer(L, cstr as string, luaGlue.lengthBytesUTF8(s), s);
+                luaGlue.stackRestore(lastStack);
+                return result;
             },
             // Note that s has a "number" type, so we can pass a raw pointer
             luaL_loadbuffer: luaGlue.cwrap("luaL_loadbuffer", "number", ["number", "number", "number", "string"]),

--- a/src/binding-factory.ts
+++ b/src/binding-factory.ts
@@ -168,6 +168,7 @@ const lauxBindings: Record<string, lauxBindingFactoryFunc> = {
                 const ptr = luaGlue.allocateUTF8(s) as unknown;
                 return (this as LauxLib).luaL_loadbuffer(L, ptr as string, luaGlue.lengthBytesUTF8(s), s);
             },
+            // Note that s has a "number" type, so we can pass a raw pointer
             luaL_loadbuffer: luaGlue.cwrap("luaL_loadbuffer", "number", ["number", "number", "number", "string"]),
             luaL_newstate: luaGlue.cwrap("lua_open", "number", []),
         }

--- a/src/binding-factory.ts
+++ b/src/binding-factory.ts
@@ -165,12 +165,14 @@ const lauxBindings: Record<string, lauxBindingFactoryFunc> = {
                 return (this as LauxLib).luaL_loadstring(L, s) || lua.lua_pcall(L, 0, LUA_MULTRET, 0);
             },
             luaL_loadstring: function(L: LuaState, s: string) {
-                return (this as LauxLib).luaL_loadbuffer(L, s, s.length, s);
+                const ptr = luaGlue.allocateUTF8(s) as unknown;
+                return (this as LauxLib).luaL_loadbuffer(L, ptr as string, luaGlue.lengthBytesUTF8(s), s);
             },
+            luaL_loadbuffer: luaGlue.cwrap("luaL_loadbuffer", "number", ["number", "number", "number", "string"]),
             luaL_newstate: luaGlue.cwrap("lua_open", "number", []),
         }
     },
-    "<=5.1.x": function(luaGlue: LuaEmscriptenModule, _lua: Lua) {
+    "5.1.x": function(luaGlue: LuaEmscriptenModule, _lua: Lua) {
         return {
             luaL_loadbuffer: luaGlue.cwrap("luaL_loadbuffer", "number", ["number", "string", "number", "string"]),
         }

--- a/src/binding-factory.ts
+++ b/src/binding-factory.ts
@@ -165,18 +165,12 @@ const lauxBindings: Record<string, lauxBindingFactoryFunc> = {
                 return (this as LauxLib).luaL_loadstring(L, s) || lua.lua_pcall(L, 0, LUA_MULTRET, 0);
             },
             luaL_loadstring: function(L: LuaState, s: string) {
-                const lastStack = luaGlue.stackSave();
-                const cstr = luaGlue.allocateUTF8OnStack(s) as unknown;
-                const result = (this as LauxLib).luaL_loadbuffer(L, cstr as string, luaGlue.lengthBytesUTF8(s), s);
-                luaGlue.stackRestore(lastStack);
-                return result;
+                return (this as LauxLib).luaL_loadbuffer(L, s, luaGlue.lengthBytesUTF8(s), s);
             },
-            // Note that s has a "number" type, so we can pass a raw pointer
-            luaL_loadbuffer: luaGlue.cwrap("luaL_loadbuffer", "number", ["number", "number", "number", "string"]),
             luaL_newstate: luaGlue.cwrap("lua_open", "number", []),
         }
     },
-    "5.1.x": function(luaGlue: LuaEmscriptenModule, _lua: Lua) {
+    "<=5.1.x": function(luaGlue: LuaEmscriptenModule, _lua: Lua) {
         return {
             luaL_loadbuffer: luaGlue.cwrap("luaL_loadbuffer", "number", ["number", "string", "number", "string"]),
         }

--- a/src/binding-factory.ts
+++ b/src/binding-factory.ts
@@ -167,18 +167,12 @@ const lauxBindings: Record<string, lauxBindingFactoryFunc> = {
             luaL_loadstring: function(L: LuaState, s: string) {
                 return (this as LauxLib).luaL_loadbuffer(L, s, s.length, s);
             },
-            luaL_loadbuffer: function(L: LuaState, s: string, slen: number, name: string) {
-                // Terrible, awful hack to prevent the end of the string from being mangled by the C wrapper
-                const pad = "              ";
-                const loadbuffer = luaGlue.cwrap("luaL_loadbuffer", "number", ["number", "string", "number", "string"]);
-                return loadbuffer(L, s + pad, slen + pad.length, name);
-            },
             luaL_newstate: luaGlue.cwrap("lua_open", "number", []),
         }
     },
-    "5.1.x": function(luaGlue: LuaEmscriptenModule, _lua: Lua) {
+    "<=5.1.x": function(luaGlue: LuaEmscriptenModule, _lua: Lua) {
         return {
-            luaL_loadbuffer: luaGlue.cwrap("luaL_loadbuffer", "number", ["number", "string", "number", "string"])
+            luaL_loadbuffer: luaGlue.cwrap("luaL_loadbuffer", "number", ["number", "string", "number", "string"]),
         }
     },
     ">=5.1.0": function(luaGlue: LuaEmscriptenModule, lua: Lua) {

--- a/src/binding-factory.ts
+++ b/src/binding-factory.ts
@@ -167,12 +167,18 @@ const lauxBindings: Record<string, lauxBindingFactoryFunc> = {
             luaL_loadstring: function(L: LuaState, s: string) {
                 return (this as LauxLib).luaL_loadbuffer(L, s, s.length, s);
             },
+            luaL_loadbuffer: function(L: LuaState, s: string, slen: number, name: string) {
+                // Terrible, awful hack to prevent the end of the string from being mangled by the C wrapper
+                const pad = "              ";
+                const loadbuffer = luaGlue.cwrap("luaL_loadbuffer", "number", ["number", "string", "number", "string"]);
+                return loadbuffer(L, s + pad, slen + pad.length, name);
+            },
             luaL_newstate: luaGlue.cwrap("lua_open", "number", []),
         }
     },
-    "<=5.1.x": function(luaGlue: LuaEmscriptenModule, _lua: Lua) {
+    "5.1.x": function(luaGlue: LuaEmscriptenModule, _lua: Lua) {
         return {
-            luaL_loadbuffer: luaGlue.cwrap("luaL_loadbuffer", "number", ["number", "string", "number", "string"]),
+            luaL_loadbuffer: luaGlue.cwrap("luaL_loadbuffer", "number", ["number", "string", "number", "string"])
         }
     },
     ">=5.1.0": function(luaGlue: LuaEmscriptenModule, lua: Lua) {

--- a/src/glue/glue.ts
+++ b/src/glue/glue.ts
@@ -1,7 +1,9 @@
 export interface LuaEmscriptenModule extends EmscriptenModule {
-    allocateUTF8: typeof allocateUTF8;
-    lengthBytesUTF8: typeof lengthBytesUTF8;
     cwrap: typeof cwrap;
+    stackSave: typeof stackSave;
+    stackRestore: typeof stackRestore;
+    lengthBytesUTF8: typeof lengthBytesUTF8;
+    allocateUTF8OnStack: typeof allocateUTF8;
 }
 
 export type EmscriptenModuleFactorySync<T extends EmscriptenModule = EmscriptenModule> = (

--- a/src/glue/glue.ts
+++ b/src/glue/glue.ts
@@ -1,4 +1,6 @@
 export interface LuaEmscriptenModule extends EmscriptenModule {
+    allocateUTF8: typeof allocateUTF8;
+    lengthBytesUTF8: typeof lengthBytesUTF8;
     cwrap: typeof cwrap;
 }
 

--- a/src/glue/glue.ts
+++ b/src/glue/glue.ts
@@ -1,9 +1,6 @@
 export interface LuaEmscriptenModule extends EmscriptenModule {
     cwrap: typeof cwrap;
-    stackSave: typeof stackSave;
-    stackRestore: typeof stackRestore;
     lengthBytesUTF8: typeof lengthBytesUTF8;
-    allocateUTF8OnStack: typeof allocateUTF8;
 }
 
 export type EmscriptenModuleFactorySync<T extends EmscriptenModule = EmscriptenModule> = (


### PR DESCRIPTION
~~This particular binding chops 14 characters from the end of the input string, corrupting the Lua payload it contains. Quite honestly, I have no idea why this behavior is happening. I first noticed it when attempting (and failing) to load TypescriptToLua's lualib bundle. We are calling the C wrapper directly, so maybe this is caused by an underlying issue with emscripten?~~

~~For Lua 5.0, we need to manually convert from a UTF-16 Node string to a UTF-8 Lua string, as this doesn't seem to be automatic.~~

The string buffer size should be Lua's UTF-8 length, not Node's UTF-16 length.